### PR TITLE
Use rsvg-convert package instead of librsvg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM minidocks/poppler
 LABEL maintainer="Martin Hasoň <martin.hason@gmail.com>"
 
-RUN apk --update add librsvg && clean
+RUN apk --update add rsvg-convert && clean
 
 COPY rootfs /
 


### PR DESCRIPTION
The librsvg package does not provide the rsvg-convert command anymore so i replaced the installed package in the Dockerfile 