### PR TITLE
Update README with fixed usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
 -----
 
 ```bash
-docker run --rm -v `pwd`:/app -w /app minidocks/librsvg http://google.com google.pdf
+docker run --rm -v `pwd`:/app -w /app minidocks/librsvg input.svg  --format=pdf --output=output.pdf
 ```
 
 Tags


### PR DESCRIPTION
The previous example does not work anymore:

- rsvg-convert expects all arguments to be input files
- the output format needs to be specified with the --format option, otherwise it defaults to png
- the output file may be with the --output option, by default it is sent to stdout